### PR TITLE
Make og:description meta tag match top of website

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta name="author" content="Luke Withey">
     <meta name="og:url" content="https://withey.tech" />
     <meta name="og:title" content="Luke Withey" />
-    <meta name="og:description" content="Software engineer in Brighton, UK. I build infrastructure, apps, and websites in small teams. In my spare time I like to climb, cycle, cook, craft, and play Ultimate." />
+    <meta name="og:description" content="Developing products for humans in the physical, digital and data dimensions." />
     <meta name="og:image" content="images/myface1.png" />
     <meta name="og:locale" content="en_GB" />
     <meta property="og:locale:alternate" content="en_US" />


### PR DESCRIPTION
This is the description that appears when someone shares a link to your website, e.g. on Twitter, Whatsapp, Slack.